### PR TITLE
Render Jinja without template

### DIFF
--- a/examples/markdown-blog/blog/hello.md
+++ b/examples/markdown-blog/blog/hello.md
@@ -1,0 +1,3 @@
+# Hello, World
+
+Hello, this fist blog post.

--- a/examples/markdown-blog/blog/test.md
+++ b/examples/markdown-blog/blog/test.md
@@ -1,2 +1,0 @@
-# Test
-This is a test.

--- a/examples/markdown-blog/blog/using-lightweight.md
+++ b/examples/markdown-blog/blog/using-lightweight.md
@@ -1,0 +1,19 @@
+# Using Lightweight
+
+Wow, such ease:
+```python
+from lightweight import Site, markdown, paths
+
+def blog_posts(site):
+    template = site.template('blog-post.html')
+    return (markdown(path, template) for path in paths('blog/**.md'))
+
+
+site = Site()
+
+site.include('index.html')
+[site.include(f'post/{post.name}.html', post) for post in blog_posts(site)]
+site.include('static')
+
+site.render()
+```

--- a/examples/markdown-blog/locate_lightweight_for_example.py
+++ b/examples/markdown-blog/locate_lightweight_for_example.py
@@ -1,0 +1,7 @@
+import os
+import sys
+from pathlib import Path
+
+_fp = Path(os.path.realpath(__file__))
+os.chdir(_fp.parent)
+sys.path.append(str(_fp.parent.parent.parent))

--- a/examples/markdown-blog/render.py
+++ b/examples/markdown-blog/render.py
@@ -1,32 +1,20 @@
 from __future__ import annotations
 
-import os
-import sys
-from pathlib import Path
+from locate_lightweight_for_example import *  # FIXME: This is only to run from inside of "lightweight" repository.
+
+from lightweight import Site, markdown, paths, render, template
 
 
-def _fix_path():
-    _fp = Path(os.path.realpath(__file__))
-    os.chdir(_fp.parent)
-    sys.path.append(str(_fp.parent.parent.parent))
-
-
-# FIXME: This is only to run from inside of "lightweight" repository.
-_fix_path()
-
-from lightweight import Site, markdown, paths
-
-
-def blog_posts(site):
-    template = site.template('blog-post.html')
-    return (markdown(path, template) for path in paths('blog/**.md'))
+def blog_posts():
+    post_template = template('blog-post.html')
+    return (markdown(path, post_template) for path in paths('blog/**.md'))
 
 
 def main():
     site = Site()
 
-    site.include('index.html')
-    [site.include(f'post/{post.name}.html', post) for post in blog_posts(site)]
+    site.include(render('index.html'))
+    [site.include(f'posts/{post.name}.html', post) for post in blog_posts()]
     site.include('static')
 
     site.render()

--- a/lightweight/__init__.py
+++ b/lightweight/__init__.py
@@ -2,4 +2,4 @@ from .content import markdown, render, template
 from .files import paths
 from .site import Site
 
-__version__ = '0.1.0.dev8'
+__version__ = '0.1.0.dev9'

--- a/lightweight/__init__.py
+++ b/lightweight/__init__.py
@@ -1,4 +1,4 @@
-from .content import Content, markdown
+from .content import markdown, render, template
 from .files import paths
 from .site import Site
 

--- a/lightweight/content.py
+++ b/lightweight/content.py
@@ -30,7 +30,7 @@ class Content(ABC):
 
     @abstractmethod
     def render(self, path: Path, site: Site):
-        ...
+        """Render..."""
 
 
 @dataclass

--- a/lightweight/errors.py
+++ b/lightweight/errors.py
@@ -1,0 +1,3 @@
+class NoSourcePath(Exception):
+    def __init__(self):
+        super().__init__('Content does not contain a valid `source_path`')

--- a/lightweight/files.py
+++ b/lightweight/files.py
@@ -1,6 +1,6 @@
 from glob import iglob
 from pathlib import Path
-from typing import Iterator, Optional
+from typing import Iterator, Optional, Union
 
 
 def create_file(path: Path, *, content: str):
@@ -9,10 +9,12 @@ def create_file(path: Path, *, content: str):
         f.write(content)
 
 
-def paths(glob_path: str) -> Iterator[Path]:
+def paths(glob_path: Union[str, Path]) -> Iterator[Path]:
     """An iterator of paths matching the provided `glob`_ pattern.
 
     _glob: https://en.wikipedia.org/wiki/Glob_(programming)"""
+    if isinstance(glob_path, Path):
+        return iter([glob_path])
     return map(Path, iglob(glob_path, recursive=True))
 
 

--- a/lightweight/files.py
+++ b/lightweight/files.py
@@ -1,6 +1,6 @@
 from glob import iglob
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, Optional
 
 
 def create_file(path: Path, *, content: str):
@@ -16,5 +16,15 @@ def paths(glob_path: str) -> Iterator[Path]:
     return map(Path, iglob(glob_path, recursive=True))
 
 
-def strip_extension(file_name: str):
-    return file_name.rsplit('.', 1)[0]
+def strip_extension(file_name: str) -> str:
+    split = file_name.rsplit('.', 1)
+    if not len(split[0]) or not len(split[1]):
+        return file_name
+    return split[0]
+
+
+def extension(file_name: str) -> Optional[str]:
+    split = file_name.rsplit('.', 1)
+    if len(split) < 2 or not len(split[0]) or not len(split[1]):
+        return None
+    return split[1]

--- a/lightweight/site.py
+++ b/lightweight/site.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from shutil import rmtree
-from typing import overload, Union, Dict
+from typing import overload, Union, Dict, Optional
 
 from lightweight.content import Content, FileCopy, DirectoryCopy
 from lightweight.errors import NoSourcePath
@@ -15,34 +15,32 @@ class Site:
         self.content = {}
 
     @overload
-    def include(self, pattern: str):
+    def include(self, arg: str) -> None:
         """Include a file or directory."""
-        ...
 
     @overload
-    def include(self, path: Union[str, Path], content: Content):
+    def include(self, arg: Union[str, Path], content: Content) -> None:
         """Create a file at path with content."""
-        ...
 
     @overload
-    def include(self, path: Content):
-        ...
+    def include(self, arg: Content) -> None:
+        """"""
 
-    def include(self, arg: Union[str, Path, Content], content: Content = None):
+    def include(self, arg: Union[str, Path, Content], content: Content = None) -> None:
         if isinstance(arg, Content):
-            source_path = getattr(arg, 'source_path', None)
+            source_path = getattr(arg, 'source_path', None)  # type: Optional[Path]
             if source_path is None:
                 raise NoSourcePath()
-            content, arg = arg, source_path
+            arg, content = source_path, arg  # type: ignore
 
+        pattern_or_path = arg  # type: Union[str, Path]
         if content is None:
-            pattern = arg
-            contents = {path: _file_or_dir(path) for path in paths(pattern)}
+            contents = {path: _file_or_dir(path) for path in paths(pattern_or_path)}
             if not len(contents):
                 raise FileNotFoundError()
             self.content.update(contents)
         else:
-            path = Path(arg)
+            path = Path(pattern_or_path)
             self.content[path] = content
 
     def render(self):

--- a/lightweight/site.py
+++ b/lightweight/site.py
@@ -2,9 +2,8 @@ from pathlib import Path
 from shutil import rmtree
 from typing import overload, Union, Dict
 
-from jinja2 import Environment, FileSystemLoader
-
 from lightweight.content import Content, FileCopy, DirectoryCopy
+from lightweight.errors import NoSourcePath
 from lightweight.files import paths
 
 
@@ -12,32 +11,39 @@ class Site:
     content: Dict[Path, Content]
 
     def __init__(self, out: Union[str, Path] = 'out'):
-        self.env = Environment(loader=FileSystemLoader('templates'))
         self.out = Path(out)
         self.content = {}
 
     @overload
-    def include(self, path_: str):
+    def include(self, pattern: str):
         """Include a file or directory."""
         ...
 
     @overload
-    def include(self, path_: str, content: Content):
+    def include(self, path: Union[str, Path], content: Content):
         """Create a file at path with content."""
         ...
 
-    def include(self, path_: str, content: Content = None):
+    @overload
+    def include(self, path: Content):
+        ...
+
+    def include(self, arg: Union[str, Path, Content], content: Content = None):
+        if isinstance(arg, Content):
+            source_path = getattr(arg, 'source_path', None)
+            if source_path is None:
+                raise NoSourcePath()
+            content, arg = arg, source_path
+
         if content is None:
-            contents = {path: _file_or_dir(path) for path in paths(path_)}
+            pattern = arg
+            contents = {path: _file_or_dir(path) for path in paths(pattern)}
             if not len(contents):
                 raise FileNotFoundError()
             self.content.update(contents)
         else:
-            path = Path(path_)
+            path = Path(arg)
             self.content[path] = content
-
-    def template(self, name):
-        return self.env.get_template(name)
 
     def render(self):
         if self.out.exists():

--- a/tests/expected/jinja-file.html
+++ b/tests/expected/jinja-file.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>jinja-file.html</title>
+</head>
+<body>
+file: jinja-file.html
+file.name: jinja-file
+file.extension: html
+
+</body>
+</html>

--- a/tests/expected/lightweight-rules.html
+++ b/tests/expected/lightweight-rules.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>99 reasons lightweight rules</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/tests/expected/md-file.html
+++ b/tests/expected/md-file.html
@@ -1,0 +1,9 @@
+<html lang="en">
+<head><title>plain.md</title></head>
+<body>
+file: plain.md
+file.name: plain
+file.extension: md
+
+</body>
+</html>

--- a/tests/resources/jinja-file.html
+++ b/tests/resources/jinja-file.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ source.file }}</title>
+</head>
+<body>
+file: {{ source.file }}
+file.name: {{ source.file.name }}
+file.extension: {{ source.file.extension }}
+
+</body>
+</html>

--- a/tests/resources/title.html
+++ b/tests/resources/title.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ title }}</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/tests/templates/md-file.html
+++ b/tests/templates/md-file.html
@@ -1,0 +1,9 @@
+<html lang="en">
+<head><title>{{ source.file }}</title></head>
+<body>
+file: {{ source.file }}
+file.name: {{ source.file.name }}
+file.extension: {{ source.file.extension }}
+
+</body>
+</html>

--- a/tests/test_include_jinja.py
+++ b/tests/test_include_jinja.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+import pytest
+
+from lightweight import Site, render
+from lightweight.content import Content
+from lightweight.errors import NoSourcePath
+
+
+def test_render_jinja(tmp_path: Path):
+    src_location = 'resources/title.html'
+    out_location = 'title.html'
+
+    out_path = tmp_path / 'out'
+    site = Site(out_path)
+
+    site.include(out_location, render(src_location, title='99 reasons lightweight rules'))
+    site.render()
+
+    assert (out_path / out_location).exists()
+    with open('expected/lightweight-rules.html') as expected:
+        assert (out_path / out_location).read_text() == expected.read()
+
+
+def test_render_jinja_shortcut(tmp_path: Path):
+    location = 'resources/title.html'
+
+    out_path = tmp_path / 'out'
+    site = Site(out_path)
+
+    site.include(render(location, title='99 reasons lightweight rules'))
+    site.render()
+
+    assert (out_path / location).exists()
+    with open('expected/lightweight-rules.html') as expected:
+        assert (out_path / location).read_text() == expected.read()
+
+
+def test_render_jinja_file(tmp_path: Path):
+    src_location = 'resources/jinja-file.html'
+    out_location = 'jinja-file.html'
+
+    out_path = tmp_path / 'out'
+    site = Site(out_path)
+
+    site.include(out_location, render(src_location))
+    site.render()
+
+    assert (out_path / out_location).exists()
+    with open('expected/jinja-file.html') as expected:
+        assert (out_path / out_location).read_text() == expected.read()
+
+
+class NoopContent(Content):
+    def render(self, path: Path, site: Site):
+        pass
+
+
+def test_render_missing_jinja_shortcut(tmp_path: Path):
+    site = Site(tmp_path / 'out')
+    with pytest.raises(NoSourcePath):
+        site.include(NoopContent())

--- a/tests/test_include_markdown.py
+++ b/tests/test_include_markdown.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from lightweight import Site, markdown
+from lightweight import Site, markdown, template
 
 
 def test_render_markdown(tmp_path: Path):
@@ -10,7 +10,7 @@ def test_render_markdown(tmp_path: Path):
     out_path = tmp_path / 'out'
     site = Site(out_path)
 
-    site.include(out_location, markdown(src_location, site.template('plain-md.html')))
+    site.include(out_location, markdown(src_location, template('plain-md.html')))
     site.render()
 
     assert (out_path / out_location).exists()
@@ -25,9 +25,24 @@ def test_render_toc(tmp_path: Path):
     out_path = tmp_path / 'out'
     site = Site(out_path)
 
-    site.include(out_location, markdown(src_location, site.template('md-toc.html')))
+    site.include(out_location, markdown(src_location, template('md-toc.html')))
     site.render()
 
     assert (out_path / out_location).exists()
     with open('expected/md-toc.html') as expected:
+        assert (out_path / out_location).read_text() == expected.read()
+
+
+def test_render_file(tmp_path: Path):
+    src_location = 'resources/plain.md'
+    out_location = 'md-file.html'
+
+    out_path = tmp_path / 'out'
+    site = Site(out_path)
+
+    site.include(out_location, markdown(src_location, template('md-file.html')))
+    site.render()
+
+    assert (out_path / out_location).exists()
+    with open('expected/md-file.html') as expected:
         assert (out_path / out_location).read_text() == expected.read()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -20,3 +20,7 @@ def test_recursive_files():
     assert set(paths('resources/glob/**/*.md')) == {Path('resources/glob/a.md'),
                                                     Path('resources/glob/b.md'),
                                                     Path('resources/glob/dir/1.md')}
+
+
+def test_path():
+    assert set(paths(Path('resources/test.html'))) == {Path('resources/test.html')}


### PR DESCRIPTION
Add `render` to render a Jinja page. 

Extract `template` from `Site`.