### PR TITLE
Paths relative to site

### DIFF
--- a/lightweight/__init__.py
+++ b/lightweight/__init__.py
@@ -1,5 +1,5 @@
-from .site import Site
-from .content import markdown, render, sass
+from .site import Site, ContentCollection, ContentAtPath
+from .content import Content, feed, markdown, render, sass
 from .files import paths
 from .template import template
 

--- a/lightweight/__init__.py
+++ b/lightweight/__init__.py
@@ -1,4 +1,4 @@
-from .site import Site, ContentCollection, ContentAtPath
+from .site import Site, SitePath
 from .content import Content, markdown, render, sass
 from .files import paths
 from .template import template

--- a/lightweight/__init__.py
+++ b/lightweight/__init__.py
@@ -1,5 +1,5 @@
 from .site import Site, ContentCollection, ContentAtPath
-from .content import Content, feed, markdown, render, sass
+from .content import Content, markdown, render, sass
 from .files import paths
 from .template import template
 

--- a/lightweight/__init__.py
+++ b/lightweight/__init__.py
@@ -1,6 +1,7 @@
-from .site import Site, SitePath
+from .site import Site
 from .content import Content, markdown, render, sass
 from .files import paths
+from .path import SitePath
 from .template import template
 
 __version__ = '0.1.0.dev13'

--- a/lightweight/__init__.py
+++ b/lightweight/__init__.py
@@ -4,4 +4,4 @@ from .files import paths
 from .path import SitePath
 from .template import template
 
-__version__ = '0.1.0.dev13'
+__version__ = '0.1.0.dev14'

--- a/lightweight/content/__init__.py
+++ b/lightweight/content/__init__.py
@@ -2,4 +2,3 @@ from .content import Content
 from .jinja import render
 from .markdown import markdown
 from .sass import sass
-from .feed import feed

--- a/lightweight/content/__init__.py
+++ b/lightweight/content/__init__.py
@@ -2,3 +2,4 @@ from .content import Content
 from .jinja import render
 from .markdown import markdown
 from .sass import sass
+from .feed import feed

--- a/lightweight/content/content.py
+++ b/lightweight/content/content.py
@@ -10,6 +10,7 @@ from lightweight.files import create_file
 
 if TYPE_CHECKING:
     from lightweight import Site
+    from lightweight.site import SitePath
 
 
 class Content(ABC):
@@ -17,11 +18,10 @@ class Content(ABC):
     site: Site
 
     @abstractmethod
-    def render(self, path: Path, site: Site):
+    def render(self, path: SitePath):
         """Render..."""
 
 
-def render_to_file(template: Template, path: Path, site: Site, **kwargs) -> None:
-    out_path = site.out / path
-    out_content = template.render(site=site, **kwargs)
-    create_file(out_path, content=out_content)
+def render_to_file(template: Template, path: SitePath, **kwargs) -> None:
+    out_content = template.render(site=path.site, **kwargs)
+    create_file(path.real_path, content=out_content)

--- a/lightweight/content/content.py
+++ b/lightweight/content/content.py
@@ -4,10 +4,6 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from jinja2 import Template
-
-from lightweight.files import create_file
-
 if TYPE_CHECKING:
     from lightweight import Site, SitePath
 
@@ -19,8 +15,3 @@ class Content(ABC):
     @abstractmethod
     def render(self, path: SitePath):
         """Render..."""
-
-
-def render_to_file(template: Template, path: SitePath, **kwargs) -> None:
-    out_content = template.render(site=path.site, **kwargs)
-    create_file(path.real_path, content=out_content)

--- a/lightweight/content/content.py
+++ b/lightweight/content/content.py
@@ -9,8 +9,7 @@ from jinja2 import Template
 from lightweight.files import create_file
 
 if TYPE_CHECKING:
-    from lightweight import Site
-    from lightweight.site import SitePath
+    from lightweight import Site, SitePath
 
 
 class Content(ABC):

--- a/lightweight/content/copy.py
+++ b/lightweight/content/copy.py
@@ -9,21 +9,21 @@ from typing import TYPE_CHECKING
 from .content import Content
 
 if TYPE_CHECKING:
-    from lightweight import Site
+    from lightweight.site import SitePath
 
 
-@dataclass
+@dataclass(frozen=True)
 class DirectoryCopy(Content):
+    source: Path
 
-    def render(self, path: Path, site: Site):
-        target = site.out / path
-        copy_tree(str(path), str(target))
+    def render(self, path: SitePath):
+        copy_tree(str(self.source), str(path.absolute()))
 
 
-@dataclass
+@dataclass(frozen=True)
 class FileCopy(Content):
+    source: Path
 
-    def render(self, path: Path, site: Site):
-        target = site.out / path
-        target.parent.mkdir(parents=True, exist_ok=True)
-        copy(str(path), str(target))
+    def render(self, path: SitePath):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        copy(str(self.source), str(path.absolute()))

--- a/lightweight/content/copy.py
+++ b/lightweight/content/copy.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from .content import Content
 
 if TYPE_CHECKING:
-    from lightweight.site import SitePath
+    from lightweight import SitePath
 
 
 @dataclass(frozen=True)

--- a/lightweight/content/copy.py
+++ b/lightweight/content/copy.py
@@ -17,6 +17,7 @@ class DirectoryCopy(Content):
     source: Path
 
     def render(self, path: SitePath):
+        path.parent.mkdir()
         copy_tree(str(self.source), str(path.absolute()))
 
 
@@ -25,5 +26,5 @@ class FileCopy(Content):
     source: Path
 
     def render(self, path: SitePath):
-        path.parent.mkdir(parents=True, exist_ok=True)
+        path.parent.mkdir()
         copy(str(self.source), str(path.absolute()))

--- a/lightweight/content/jinja.py
+++ b/lightweight/content/jinja.py
@@ -10,7 +10,7 @@ from lightweight.files import FileName
 from .content import render_to_file, Content
 
 if TYPE_CHECKING:
-    from lightweight import Site
+    from lightweight.site import SitePath
 
 jinja_cwd = Environment(loader=FileSystemLoader('./.', followlinks=True))
 
@@ -22,8 +22,8 @@ class JinjaSource(Content):
     params: Dict[str, Any]
     template: Template
 
-    def render(self, path: Path, site: Site):
-        render_to_file(self.template, path, site, source=self, **self.params)
+    def render(self, path: SitePath):
+        render_to_file(self.template, path, source=self, **self.params)
 
 
 def render(template_path: Union[str, Path], **params) -> JinjaSource:

--- a/lightweight/content/jinja.py
+++ b/lightweight/content/jinja.py
@@ -7,7 +7,7 @@ from typing import Optional, Dict, Any, Union, TYPE_CHECKING
 from jinja2 import Environment, FileSystemLoader, Template
 
 from lightweight.files import FileName
-from .content import render_to_file, Content
+from .content import Content
 
 if TYPE_CHECKING:
     from lightweight import SitePath
@@ -23,7 +23,9 @@ class JinjaSource(Content):
     template: Template
 
     def render(self, path: SitePath):
-        render_to_file(self.template, path, source=self, **self.params)
+        path.create(self.template.render(
+            site=path.site, source=self, **self.params
+        ))
 
 
 def render(template_path: Union[str, Path], **params) -> JinjaSource:

--- a/lightweight/content/jinja.py
+++ b/lightweight/content/jinja.py
@@ -10,7 +10,7 @@ from lightweight.files import FileName
 from .content import render_to_file, Content
 
 if TYPE_CHECKING:
-    from lightweight.site import SitePath
+    from lightweight import SitePath
 
 jinja_cwd = Environment(loader=FileSystemLoader('./.', followlinks=True))
 

--- a/lightweight/content/markdown.py
+++ b/lightweight/content/markdown.py
@@ -12,7 +12,7 @@ from .content import Content, render_to_file
 from .lwmd import LwMarkdown
 
 if TYPE_CHECKING:
-    from lightweight import Site
+    from lightweight import SitePath
 
 
 @dataclass(frozen=True)
@@ -22,7 +22,7 @@ class MarkdownSource(Content):
     content: str  # the contents of a file
     template: Template
 
-    def render(self, path: Path):
+    def render(self, path: SitePath):
         html, toc_html = LwMarkdown().render(self.content)
         render_to_file(
             self.template, path,

--- a/lightweight/content/markdown.py
+++ b/lightweight/content/markdown.py
@@ -8,7 +8,7 @@ from typing import Optional, Union, TYPE_CHECKING
 from jinja2 import Template
 
 from lightweight.files import FileName
-from .content import Content, render_to_file
+from .content import Content
 from .lwmd import LwMarkdown
 
 if TYPE_CHECKING:
@@ -24,8 +24,9 @@ class MarkdownSource(Content):
 
     def render(self, path: SitePath):
         html, toc_html = LwMarkdown().render(self.content)
-        render_to_file(
-            self.template, path,
+        path.create(self.template.render(
+            site=path.site,
+            source=self,
             markdown=RenderedMarkdown(
                 html=html,
                 toc_html=toc_html,
@@ -34,9 +35,8 @@ class MarkdownSource(Content):
                 title=None,
                 updated=None,
                 created=None
-            ),
-            source=self,
-        )
+            )
+        ))
 
 
 def markdown(md_path: Union[str, Path], template: Template) -> MarkdownSource:

--- a/lightweight/content/markdown.py
+++ b/lightweight/content/markdown.py
@@ -15,17 +15,17 @@ if TYPE_CHECKING:
     from lightweight import Site
 
 
-@dataclass
+@dataclass(frozen=True)
 class MarkdownSource(Content):
     file: FileName  # name of markdown file
     source_path: Optional[Path]
     content: str  # the contents of a file
     template: Template
 
-    def render(self, path: Path, site: Site):
+    def render(self, path: Path):
         html, toc_html = LwMarkdown().render(self.content)
         render_to_file(
-            self.template, path, site,
+            self.template, path,
             markdown=RenderedMarkdown(
                 html=html,
                 toc_html=toc_html,
@@ -51,7 +51,7 @@ def markdown(md_path: Union[str, Path], template: Template) -> MarkdownSource:
     )
 
 
-@dataclass
+@dataclass(frozen=True)
 class RenderedMarkdown:
     html: str
     toc_html: str

--- a/lightweight/content/sass.py
+++ b/lightweight/content/sass.py
@@ -10,7 +10,7 @@ from lightweight.files import paths
 from .content import Content
 
 if TYPE_CHECKING:
-    from lightweight.site import SitePath
+    from lightweight import SitePath
 
 
 @dataclass(frozen=True)

--- a/lightweight/content/sass.py
+++ b/lightweight/content/sass.py
@@ -10,34 +10,33 @@ from lightweight.files import paths
 from .content import Content
 
 if TYPE_CHECKING:
-    from lightweight import Site
+    from lightweight.site import SitePath
 
 
-@dataclass
+@dataclass(frozen=True)
 class Sass(Content):
     source_path: Path
 
-    def render(self, path: Path, site: Site):
+    def render(self, path: SitePath):
         if self.source_path.is_dir():
             css_at_target = construct_relative_css_path(self.source_path, target=path)
-            [_render(p, css_at_target(p), site.out) for p in paths(f'{self.source_path}/**/*.sass')]
-            [_render(p, css_at_target(p), site.out) for p in paths(f'{self.source_path}/**/*.scss')]
+            [_render(p, css_at_target(p)) for p in paths(f'{self.source_path}/**/*.sass')]
+            [_render(p, css_at_target(p)) for p in paths(f'{self.source_path}/**/*.scss')]
         else:
-            _render(self.source_path, path, site.out)
+            _render(self.source_path, path)
 
 
-def construct_relative_css_path(source: Path, *, target: Path) -> Callable[[Path], Path]:
+def construct_relative_css_path(source: Path, *, target: SitePath) -> Callable[[Path], SitePath]:
     start = len(source.parts)
 
-    def remap(path):
+    def remap(path: Path) -> SitePath:
         relative_parts = path.parts[start:]
-        return Path(*target.parts, *relative_parts).with_suffix('.css')
+        return target.site.path(Path(*target.parts, *relative_parts)).with_suffix('.css')
 
     return remap
 
 
-def _render(source: Path, target: Path, out_root: Path):
-    out_path = out_root / target
+def _render(source: Path, target: SitePath):
     sourcemap_path = target.with_name(target.name + '.map')
     result, sourcemap = compile(
         filename=str(source),
@@ -46,8 +45,8 @@ def _render(source: Path, target: Path, out_root: Path):
         source_map_contents=True,
         output_style='compact',
     )
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    with out_path.open('w') as css_file, (out_root / sourcemap_path).open('w') as sourcemap_file:
+    target.parent.mkdir()
+    with target.open('w') as css_file, sourcemap_path.open('w') as sourcemap_file:
         css_file.write(result)
         sourcemap_file.write(sourcemap)
 

--- a/lightweight/files.py
+++ b/lightweight/files.py
@@ -36,6 +36,7 @@ class FileName(str):
 
     @property
     def name(self):
+        # TODO:mdrachuk:2019-09-01: rename to stem
         return strip_extension(self)
 
     @property

--- a/lightweight/files.py
+++ b/lightweight/files.py
@@ -3,12 +3,6 @@ from pathlib import Path
 from typing import Iterator, Optional, Union
 
 
-def create_file(path: Path, *, content: str):
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open('w') as f:
-        f.write(content)
-
-
 def paths(glob_path: Union[str, Path]) -> Iterator[Path]:
     """An iterator of paths matching the provided `glob`_ pattern.
 

--- a/lightweight/path.py
+++ b/lightweight/path.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path, PurePath
+from typing import Union, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lightweight import Site
+
+
+class SitePath:
+
+    def __init__(self, path: Union[Path, str], site: Site):
+        self.site = site
+        self.relative_path = Path(path) if isinstance(path, str) else path
+
+    @property
+    def real_path(self):
+        return self.site.out / self.relative_path
+
+    @property
+    def name(self):
+        return self.relative_path.name
+
+    @property
+    def parts(self) -> Tuple[str, ...]:
+        return self.relative_path.parts
+
+    @property
+    def parent(self) -> SitePath:
+        return self.site.path(self.relative_path.parent)
+
+    def absolute(self) -> Path:
+        return self.real_path.absolute()
+
+    def exists(self) -> bool:
+        return self.real_path.exists()
+
+    def mkdir(self, mode=0o777, parents=True, exist_ok=True):
+        return self.real_path.mkdir(mode=mode, parents=parents, exist_ok=exist_ok)
+
+    def __truediv__(self, other: Union[SitePath, PurePath]):
+        other_path: PurePath
+        if isinstance(other, SitePath):
+            other_path = other.relative_path
+        elif isinstance(other, PurePath):
+            other_path = other
+        else:
+            raise ValueError(f'Cannot make a path with {other}')
+        return self.site.path(self.relative_path / other_path)
+
+    def __str__(self):
+        return str(self.relative_path)
+
+    def with_name(self, name: str) -> SitePath:
+        return self.site.path(self.relative_path.with_name(name))
+
+    def open(self, mode='r', buffering=-1, encoding=None, errors=None, newline=None):
+        return self.real_path.open(mode=mode, buffering=buffering, encoding=encoding, errors=errors, newline=newline)
+
+    def with_suffix(self, suffix: str) -> SitePath:
+        return self.site.path(self.relative_path.with_suffix(suffix))

--- a/lightweight/path.py
+++ b/lightweight/path.py
@@ -8,6 +8,17 @@ if TYPE_CHECKING:
 
 
 class SitePath:
+    """An implementation of Path interface.
+    File system operations performed on real_path; relative path is used for all other operations.
+
+    `__str__` returns relative path representation.
+
+    Changed defaults:
+    - mkdir -- parents and exists_ok are made `True`.
+
+    Added:
+    - create -- create file with contents.
+    """
 
     def __init__(self, path: Union[Path, str], site: Site):
         self.site = site
@@ -59,3 +70,8 @@ class SitePath:
 
     def with_suffix(self, suffix: str) -> SitePath:
         return self.site.path(self.relative_path.with_suffix(suffix))
+
+    def create(self, content: str) -> None:
+        self.parent.mkdir()
+        with self.open('w') as f:
+            f.write(content)

--- a/lightweight/site.py
+++ b/lightweight/site.py
@@ -1,67 +1,14 @@
 from __future__ import annotations
 
-from pathlib import Path, PurePath
+from pathlib import Path
 from shutil import rmtree
-from typing import overload, Union, Optional, Tuple, Dict
+from typing import overload, Union, Optional, Dict
 
+from lightweight.path import SitePath
 from lightweight.content import Content
 from lightweight.content.copy import FileCopy, DirectoryCopy
 from lightweight.errors import NoSourcePath
 from lightweight.files import paths
-
-
-class SitePath:
-
-    def __init__(self, path: Union[Path, str], site: Site):
-        self.site = site
-        self.relative_path = Path(path) if isinstance(path, str) else path
-
-    @property
-    def real_path(self):
-        return self.site.out / self.relative_path
-
-    @property
-    def name(self):
-        return self.relative_path.name
-
-    @property
-    def parts(self) -> Tuple[str, ...]:
-        return self.relative_path.parts
-
-    @property
-    def parent(self) -> SitePath:
-        return self.site.path(self.relative_path.parent)
-
-    def absolute(self) -> Path:
-        return self.real_path.absolute()
-
-    def exists(self) -> bool:
-        return self.real_path.exists()
-
-    def mkdir(self, mode=0o777, parents=True, exist_ok=True):
-        return self.real_path.mkdir(mode=mode, parents=parents, exist_ok=exist_ok)
-
-    def __truediv__(self, other: Union[SitePath, PurePath]):
-        other_path: PurePath
-        if isinstance(other, SitePath):
-            other_path = other.relative_path
-        elif isinstance(other, PurePath):
-            other_path = other
-        else:
-            raise ValueError(f'Cannot make a path with {other}')
-        return self.site.path(self.relative_path / other_path)
-
-    def __str__(self):
-        return str(self.relative_path)
-
-    def with_name(self, name: str) -> SitePath:
-        return self.site.path(self.relative_path.with_name(name))
-
-    def open(self, mode='r', buffering=-1, encoding=None, errors=None, newline=None):
-        return self.real_path.open(mode=mode, buffering=buffering, encoding=encoding, errors=errors, newline=newline)
-
-    def with_suffix(self, suffix: str) -> SitePath:
-        return self.site.path(self.relative_path.with_suffix(suffix))
 
 
 class Site:

--- a/lightweight/site.py
+++ b/lightweight/site.py
@@ -1,6 +1,8 @@
-from pathlib import Path
+from __future__ import annotations
+
+from pathlib import Path, PurePath
 from shutil import rmtree
-from typing import overload, Union, Dict, Optional
+from typing import overload, Union, Dict, Optional, Mapping, Any, Tuple
 
 from lightweight.content import Content
 from lightweight.content.copy import FileCopy, DirectoryCopy
@@ -8,26 +10,91 @@ from lightweight.errors import NoSourcePath
 from lightweight.files import paths
 
 
-class Site:
-    content: Dict[Path, Content]
+class SitePath:
+
+    def __init__(self, path: Union[Path, str], site: Site):
+        self.site = site
+        self.relative_path = Path(path) if isinstance(path, str) else path
+
+    @property
+    def real_path(self):
+        return self.site.out / self.relative_path
+
+    @property
+    def name(self):
+        return self.relative_path.name
+
+    @property
+    def parts(self) -> Tuple[str]:
+        return self.relative_path.parts
+
+    @property
+    def parent(self) -> SitePath:
+        return self.site.path(self.relative_path.parent)
+
+    def absolute(self) -> Path:
+        return self.real_path.absolute()
+
+    def exists(self) -> bool:
+        return self.real_path.exists()
+
+    def mkdir(self, mode=0o777, parents=True, exist_ok=True):
+        return self.real_path.mkdir(mode=mode, parents=parents, exist_ok=exist_ok)
+
+    def __truediv__(self, other: Union[SitePath, PurePath]):
+        if isinstance(other, SitePath):
+            other_path = other.relative_path
+        elif isinstance(other, PurePath):
+            other_path = other
+        else:
+            raise ValueError(f'Cannot make a path with {other}')
+        return self.site.path(self.relative_path / other_path)
+
+    def __str__(self):
+        return str(self.relative_path)
+
+    def with_name(self, name: str) -> SitePath:
+        return self.site.path(self.relative_path.with_name(name))
+
+    def open(self, mode='r', buffering=-1, encoding=None, errors=None, newline=None):
+        return self.real_path.open(mode=mode, buffering=buffering, encoding=encoding, errors=errors, newline=newline)
+
+    def with_suffix(self, suffix: str) -> SitePath:
+        return self.site.path(self.relative_path.with_suffix(suffix))
+
+
+class ContentCollection:
+
+    def __init__(self, content: Mapping[SitePath, Content]):
+        self.content = dict(content)
+
+    def __getitem__(self, path_part: str) -> ContentAtPath:
+        return ContentAtPath(Path(path_part), {
+            path: content
+            for path, content in self.content.items()
+            if path.parts[0] == path_part
+        }, self)
+
+
+class Site(ContentCollection):
 
     def __init__(self, out: Union[str, Path] = 'out'):
+        super().__init__({})
         self.out = Path(out)
-        self.content = {}
 
     @overload
-    def include(self, arg: str) -> None:
+    def include(self, arg: str):
         """Include a file or directory."""
 
     @overload
-    def include(self, arg: Union[str, Path], content: Content) -> None:
+    def include(self, arg: Union[str, Path], content: Content):
         """Create a file at path with content."""
 
     @overload
-    def include(self, arg: Content) -> None:
+    def include(self, arg: Content):
         """"""
 
-    def include(self, arg: Union[str, Path, Content], content: Content = None) -> None:
+    def include(self, arg: Union[str, Path, Content], content: Content = None):
         if isinstance(arg, Content):
             source_path = getattr(arg, 'source_path', None)  # type: Optional[Path]
             if source_path is None:
@@ -36,20 +103,43 @@ class Site:
 
         pattern_or_path = arg  # type: Union[str, Path]
         if content is None:
-            contents = {path: _file_or_dir(path) for path in paths(pattern_or_path)}
+            contents = {self.path(path): _file_or_dir(path) for path in paths(pattern_or_path)}
             if not len(contents):
                 raise FileNotFoundError()
             self.content.update(contents)
         else:
-            path = Path(pattern_or_path)
+            path = self.path(pattern_or_path)
             self.content[path] = content
+
+    def path(self, p: Union[Path, str]) -> SitePath:
+        return SitePath(p, self)
 
     def render(self):
         if self.out.exists():
             rmtree(self.out)
-        self.out.mkdir()
-        [content.render(path, self) for path, content in self.content.items()]
+        self.out.mkdir(parents=True, exist_ok=True)
+        [content.render(path) for path, content in self.content.items()]
 
 
 def _file_or_dir(path: Path):
-    return FileCopy() if path.is_file() else DirectoryCopy()
+    return FileCopy(path) if path.is_file() else DirectoryCopy(path)
+
+
+class ContentAtPath(ContentCollection):
+
+    def __init__(self, path: SitePath, content: Dict[SitePath, Content], source: Any):
+        super().__init__(content)
+        self.rel_path = path
+        self.base_size = len(self.rel_path.parts)
+
+        self.id = self.rel_path
+        self.title = path
+        self.author_name = getattr(source, 'author_name', None)
+        self.author_email = getattr(source, 'author_email', None)
+
+    def __getitem__(self, path_part: str):
+        return ContentAtPath(Path(path_part), {
+            path: content
+            for path, content in self.content.items()
+            if path.parts[self.base_size] == path_part
+        }, self)

--- a/tests/test_include_jinja.py
+++ b/tests/test_include_jinja.py
@@ -52,7 +52,7 @@ def test_render_jinja_file(tmp_path: Path):
 
 
 class NoopContent(Content):
-    def render(self, path: Path, site: Site):
+    def render(self, path: Path):
         pass
 
 


### PR DESCRIPTION
Site is organized via paths relative to site output root. This leads to errors when user has to organize relative/absolute paths himself. 

SitePath makes life easier by behaving like a relative path all the time except for actual file system calls.