### PR TITLE
Markdown links and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Static site generator i actually can use.
 - [x] Clean and easily extensible API 
 - [x] Jinja2 templates
 - [x] Markdown rendering
-- [ ] Markdown links
 - [x] Sass/SCSS rendering
 - [x] RSS/Atom feeds
-- [ ] Dev server
+- [x] Dev server
+- [ ] CLI
 
 ## Installation
 Available from [PyPI][pypi]:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install lightweight
 
 ## Quick Example
 ```python
-from lightweight import Site, markdown, paths, render, template, feeds, sass
+from lightweight import Site, markdown, paths, render, template, rss, atom, sass
 
 
 def blog_posts():
@@ -36,19 +36,20 @@ def blog_posts():
     return (markdown(path, post_template) for path in paths('posts/**.md'))
 
 
-site = Site(url='https://example.com')
+site = Site(url='https://example.org')
 
-# Render a Jinja2 template.
-site.include('index.html', render('pages/index.html')) 
+# Render an index page from Jinja2 template.
+site.include('index.html', render('pages/index.html'))
 
-# Render list of Markdown files.
-site.include('posts.html', render('pages/posts.html'))
+# Render markdown blog posts.
 [site.include(f'posts/{post.filename.stem}.html', post) for post in blog_posts()]
+site.include('posts.html', render('pages/posts.html'))
 
 # Syndicate RSS and Atom feeds.
-[site.include(f'posts.{type}.xml', feed) for type, feed in feeds(site['posts'])]
+site.include(f'posts.atom.xml', atom(site['posts']))
+site.include(f'posts.rss.xml', rss(site['posts']))
 
-# Render SCSS.
+# Render SASS to CSS.
 site.include('css/style.css', sass('styles/style.scss'))
 
 # Include a copy of a directory.
@@ -71,6 +72,9 @@ The live reload can be disabled with `--no-live-reload` flag:
 ```bash
 python -m lightweight.server <directory> --no-live-reload
 ```
+Otherwise every served html file will be injected with a javascript that polls `/id`.
+The script reloads the page when the `/id` changes.
+The `/id` changes every time on any file change at the served directory.
 
 Host and port can be set via:
 ```bash

--- a/examples/markdown-blog/posts/hello.md
+++ b/examples/markdown-blog/posts/hello.md
@@ -1,3 +1,3 @@
 # Hello, World
 
-Hello, this fist blog post.
+Hello, this first blog post.

--- a/examples/markdown-blog/posts/hello.md
+++ b/examples/markdown-blog/posts/hello.md
@@ -1,3 +1,5 @@
 # Hello, World
 
 Hello, this first blog post.
+
+Make sure to read [Using Lightweigh](/posts/using-lightweight.md).

--- a/examples/markdown-blog/render.py
+++ b/examples/markdown-blog/render.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from locate_lightweight_for_example import *
+from argparse import ArgumentParser
+
 from lightweight import Site, markdown, paths, render, template, sass, atom, rss
 
 
@@ -9,8 +10,8 @@ def blog_posts():
     return (markdown(path, post_template) for path in paths('posts/**.md'))
 
 
-def dev():
-    site = Site(url='http://localhost:8080')
+def main(dev: bool = False):
+    site = Site(url='http://localhost:8080' if dev else 'http://example.org')
 
     # Render an index page from Jinja2 template.
     site.include('index.html', render('pages/index.html'))
@@ -33,5 +34,9 @@ def dev():
     site.render()
 
 
+parser = ArgumentParser(description='Render a static website')
+parser.add_argument('--dev', action='store_true', default=False, help='dev configuration')
+
 if __name__ == '__main__':
-    dev()
+    args = parser.parse_args()
+    main(dev=args.dev)

--- a/examples/markdown-blog/render.py
+++ b/examples/markdown-blog/render.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from lightweight import Site, markdown, paths, render, template, sass, feeds
-from lightweight.template import jinja
 
 
 def blog_posts():
@@ -10,8 +9,6 @@ def blog_posts():
 
 
 def dev():
-    jinja.globals['DEV_ENVIRONMENT'] = True
-
     site = Site(url='http://localhost:8080')
 
     # Render an index page from Jinja2 template.
@@ -32,8 +29,6 @@ def dev():
     site.include('images')
 
     site.render()
-
-    jinja.globals['DEV_ENVIRONMENT'] = False
 
 
 if __name__ == '__main__':

--- a/examples/markdown-blog/render.py
+++ b/examples/markdown-blog/render.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from lightweight import Site, markdown, paths, render, template, sass, feeds
+from locate_lightweight_for_example import *
+from lightweight import Site, markdown, paths, render, template, sass, atom, rss
 
 
 def blog_posts():
@@ -19,7 +20,8 @@ def dev():
     site.include('posts.html', render('pages/posts.html'))
 
     # Syndicate RSS and Atom feeds.
-    [site.include(f'posts.{type}.xml', feed) for type, feed in feeds(site['posts'])]
+    site.include(f'posts.atom.xml', atom(site['posts']))
+    site.include(f'posts.rss.xml', rss(site['posts']))
 
     # Render SASS to CSS.
     site.include('styles/lightweight.css', sass('styles/lightweight.scss'))

--- a/lightweight/__init__.py
+++ b/lightweight/__init__.py
@@ -4,4 +4,4 @@ from .files import paths
 from .path import SitePath
 from .template import template
 
-__version__ = '1.0.0.dev20'
+__version__ = '1.0.0.dev21'

--- a/lightweight/__init__.py
+++ b/lightweight/__init__.py
@@ -4,4 +4,4 @@ from .files import paths
 from .path import SitePath
 from .template import template
 
-__version__ = '1.0.0.dev19'
+__version__ = '1.0.0.dev20'

--- a/lightweight/__init__.py
+++ b/lightweight/__init__.py
@@ -1,5 +1,5 @@
 from .site import Site
-from .content import Content, ContentCollection, feeds, markdown, render, sass
+from .content import Content, ContentCollection, feeds, atom, rss, markdown, render, sass
 from .files import paths
 from .path import SitePath
 from .template import template

--- a/lightweight/content/__init__.py
+++ b/lightweight/content/__init__.py
@@ -1,6 +1,6 @@
 from .collection import ContentCollection
 from .content import Content
-from .feeds import feeds
+from .feeds import atom, rss
 from .jinja import render
 from .markdown import markdown
 from .sass import sass

--- a/lightweight/content/collection.py
+++ b/lightweight/content/collection.py
@@ -102,8 +102,7 @@ class EntryCollection(ABC):
         )
 
 
-class \
-        ContentAtPath(EntryCollection, ContentCollection):
+class ContentAtPath(EntryCollection, ContentCollection):
     """Content Collection retrieved by accessing other content collection by path:
 
             :Example:

--- a/lightweight/content/content.py
+++ b/lightweight/content/content.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import datetime
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from lightweight import Site, SitePath
+    from lightweight import SitePath
 
 # Type aliases for clear type definitions
 Url = str
@@ -14,12 +13,10 @@ Email = str
 
 
 class Content(ABC):
-    path: Path
-    site: Site
 
     @abstractmethod
-    def render(self, path: SitePath):
-        """Render..."""
+    def write(self, path: SitePath):
+        """Write..."""
 
 
 class Entry(ABC):
@@ -32,23 +29,3 @@ class Entry(ABC):
     author_email: Email
     created: datetime
     updated: datetime
-
-
-class ByteContent(Content, bytes):
-    """Bytes that can be redered to path.
-
-        :Example:
-
-        >>> binary_content = ByteContent(b'1234')
-        >>> binary_content.render(site.path('out/digits.bin'))
-    """
-
-    def render(self, path: SitePath):
-        path.create(self)
-
-    def __repr__(self):
-        return f'<{self.__class__.__name__} {truncate(self)}>'
-
-
-def truncate(data: bytes, size=16) -> str:
-    return f'{data[:size].decode("utf8")}..' if len(data) > size else data.decode("utf8")

--- a/lightweight/content/copy.py
+++ b/lightweight/content/copy.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 class DirectoryCopy(Content):
     source: Path
 
-    def render(self, path: SitePath):
+    def write(self, path: SitePath):
         path.parent.mkdir()
         copy_tree(str(self.source), str(path.absolute()))
 
@@ -25,6 +25,6 @@ class DirectoryCopy(Content):
 class FileCopy(Content):
     source: Path
 
-    def render(self, path: SitePath):
+    def write(self, path: SitePath):
         path.parent.mkdir()
         copy(str(self.source), str(path.absolute()))

--- a/lightweight/content/feeds.py
+++ b/lightweight/content/feeds.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path
-from typing import TYPE_CHECKING, TypeVar, Any, Optional, Type, Union, List, Mapping
+from typing import TYPE_CHECKING, TypeVar, Any, Optional, Type, List, Mapping, Union
 from urllib.parse import urljoin
 
 from feedgen.entry import FeedEntry  # type: ignore
@@ -139,10 +138,10 @@ def rss(source: ContentCollection) -> RssFeed:
     return new_feed(RssFeed, source)
 
 
-FeedFactory = Type[Union[RssFeed, AtomFeed]]
+F = TypeVar('F', RssFeed, AtomFeed)
 
 
-def new_feed(feed: FeedFactory, source: ContentCollection) -> Union[RssFeed, AtomFeed]:
+def new_feed(feed: Type[F], source: ContentCollection) -> F:
     """Create RSS and Atom feeds."""
 
     url = required(source, 'url')
@@ -173,7 +172,7 @@ def new_feed(feed: FeedFactory, source: ContentCollection) -> Union[RssFeed, Ato
     )
 
 
-def new_entry(path: Path, content: Content, author: Any, root_url: Url, ):
+def new_entry(path: SitePath, content: Content, author: Any, root_url: Url, ):
     """Fill the provided FeedEntry with content."""
     url = get(content, 'url', default=urljoin(root_url, str(path)))
     title = get(content, 'title', default=str(path))
@@ -201,7 +200,7 @@ def required(obj, field: str) -> Any:
     return value
 
 
-def get(obj, field: str, *, default: Optional[T]) -> Optional[T]:
+def get(obj, field: str, *, default: T) -> Union[T, Any]:
     """Get a field from object, with a default value in case its not present, None, or empty."""
     value = getattr(obj, field, None)
     if not value and value is not False and value != 0:

--- a/lightweight/content/feeds.py
+++ b/lightweight/content/feeds.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeVar, Any, Optional, Type, Union, Dict, List
+from typing import TYPE_CHECKING, TypeVar, Any, Optional, Type, Union, List, Mapping
 from urllib.parse import urljoin
 
 from feedgen.entry import FeedEntry  # type: ignore
@@ -28,7 +28,7 @@ class RssFeed(Content):
     title: str
     description: str
     updated: Optional[str]
-    author: Dict[str, Optional[str]]
+    author: Mapping[str, Optional[str]]
     language: Optional[LanguageCode]
     copyright: Optional[str]
 
@@ -70,7 +70,7 @@ class AtomFeed(Content):
     title: str
     description: str
     updated: Optional[datetime]
-    author: Dict[str, Optional[str]]
+    author: Mapping[str, Optional[str]]
     language: Optional[str]
     copyright: Optional[str]
 
@@ -108,7 +108,7 @@ class AtomFeed(Content):
 class Entry:
     url: str
     title: str
-    author: Dict[str, str]
+    author: Mapping[str, Optional[str]]
     created: datetime
     updated: datetime
     summary: str
@@ -173,12 +173,7 @@ def new_feed(feed: FeedFactory, source: ContentCollection) -> Union[RssFeed, Ato
     )
 
 
-def new_entry(
-        path: Path,
-        content: Content,
-        author: Any,
-        root_url: Url,
-):
+def new_entry(path: Path, content: Content, author: Any, root_url: Url, ):
     """Fill the provided FeedEntry with content."""
     url = get(content, 'url', default=urljoin(root_url, str(path)))
     title = get(content, 'title', default=str(path))

--- a/lightweight/content/jinja.py
+++ b/lightweight/content/jinja.py
@@ -21,7 +21,7 @@ class JinjaSource(Content):
     params: Dict[str, Any]
     template: Template
 
-    def render(self, path: SitePath):
+    def write(self, path: SitePath):
         path.create(self.template.render(
             site=path.site, source=self, **self.params
         ))

--- a/lightweight/content/lwmd.py
+++ b/lightweight/content/lwmd.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import namedtuple
-from typing import List
+from typing import List, Dict
 
 import mistune  # type: ignore # no typings
 from slugify import slugify  # type: ignore # no typings
@@ -70,13 +70,26 @@ class TocMixin(object):
 
 class LwRenderer(TocMixin, mistune.Renderer):
 
+    def __init__(self, link_mapping: Dict[str, str]):
+        super().__init__()
+        self.url_mapping = link_mapping
+
     def reset(self):
         super(LwRenderer, self).reset()
 
+    def link(self, link, title, text):
+        if link.startswith('/'):
+            without_slash = link[1:]
+            if without_slash in self.url_mapping:
+                link = self.url_mapping[without_slash]
+        elif link in self.url_mapping:
+            link = self.url_mapping[link]
+        return super().link(link, title, text)
+
 
 class LwMarkdown(mistune.Markdown):
-    def __init__(self):
-        super().__init__(renderer=LwRenderer())
+    def __init__(self, link_mapping: Dict[str, str]):
+        super().__init__(renderer=LwRenderer(link_mapping))
 
     def render(self, text):
         self.renderer.reset()

--- a/lightweight/content/markdown.py
+++ b/lightweight/content/markdown.py
@@ -28,7 +28,14 @@ class MarkdownPage(Content):
     updated: Optional[datetime] = None
 
     def render(self, site: Site):
-        html, toc_html = LwMarkdown().render(self.source)
+        md_paths = {
+            str(content.source_path): site.path(path).url
+            for path, content in site.content.items()
+            if isinstance(content, MarkdownPage)
+        }
+        locations = {str(path): site.path(path).url for path in site.content}
+        link_mapping = dict(**md_paths, **locations)
+        html, toc_html = LwMarkdown(link_mapping).render(self.source)
         return RenderedMarkdown(
             html=html,
             toc_html=toc_html,

--- a/lightweight/content/markdown.py
+++ b/lightweight/content/markdown.py
@@ -29,11 +29,11 @@ class MarkdownPage(Content):
 
     def render(self, site: Site):
         md_paths = {
-            str(content.source_path): site.path(path).url
-            for path, content in site.content.items()
+            str(content.source_path): path.url
+            for path, content in site.items()
             if isinstance(content, MarkdownPage)
         }
-        locations = {str(path): site.path(path).url for path in site.content}
+        locations = {str(path): path.url for path in site}
         link_mapping = dict(**md_paths, **locations)
         html, toc_html = LwMarkdown(link_mapping).render(self.source)
         return RenderedMarkdown(

--- a/lightweight/content/sass.py
+++ b/lightweight/content/sass.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 class Sass(Content):
     source_path: Path
 
-    def render(self, path: SitePath):
+    def write(self, path: SitePath):
         if self.source_path.is_dir():
             css_at_target = construct_relative_css_path(self.source_path, target=path)
             [_render(p, css_at_target(p)) for p in paths(f'{self.source_path}/**/*.sass')]

--- a/lightweight/path.py
+++ b/lightweight/path.py
@@ -58,11 +58,11 @@ class SitePath:
     def mkdir(self, mode=0o777, parents=True, exist_ok=True):
         return self.real_path.mkdir(mode=mode, parents=parents, exist_ok=exist_ok)
 
-    def __truediv__(self, other: Union[SitePath, PurePath]):
-        other_path: PurePath
+    def __truediv__(self, other: Union[SitePath, PurePath, str]):
+        other_path: Union[PurePath, str]
         if isinstance(other, SitePath):
             other_path = other.relative_path
-        elif isinstance(other, PurePath):
+        elif isinstance(other, PurePath) or isinstance(other, str):
             other_path = other
         else:
             raise ValueError(f'Cannot make a path with {other}')

--- a/lightweight/server.py
+++ b/lightweight/server.py
@@ -91,7 +91,7 @@ class DevSever(HTTPServer):
         handler = LiveStaticFiles if enable_reload else StaticFiles
         super(DevSever, self).__init__(address, handler)
         if enable_reload:
-            _, self.id_path = mkstemp()  # type: ignore
+            _, self.id_path = mkstemp()
 
 
 def check_directory(working_dir: Path):
@@ -168,7 +168,7 @@ if __name__ == '__main__':
     server = DevSever(args.directory, host=args.host, port=args.port, enable_reload=enable_reload)
 
     if enable_reload:
-        id_path = server.id_path  # type
+        id_path = server.id_path
         observer = Observer()
         observer.schedule(ChangeId(id_path), args.directory, recursive=True)
         observer.start()

--- a/lightweight/server.py
+++ b/lightweight/server.py
@@ -4,7 +4,11 @@ from enum import Enum, auto
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from mimetypes import types_map
 from pathlib import Path
+from tempfile import mkstemp
 from uuid import uuid4
+
+from watchdog.events import FileSystemEventHandler  # type: ignore
+from watchdog.observers import Observer  # type: ignore
 
 
 class FileType(Enum):
@@ -64,7 +68,9 @@ class LiveStaticFiles(StaticFiles):
         if self.path == '/id':
             self.send_response(200)
             self.end_headers()
-            self.wfile.write(self.server.id.encode('utf8'))
+            with open(self.server.id_path) as f:
+                id = f.read()
+            self.wfile.write(id.encode('utf8'))
         else:
             super().do_GET()
 
@@ -77,15 +83,15 @@ class LiveStaticFiles(StaticFiles):
         return file.content
 
 
-def dev_server(directory: str, *, host: str, port: int, enable_reload: bool) -> HTTPServer:
-    working_dir = Path(directory).resolve()
-    check_directory(working_dir)
-    address = (host, port)
-    handler = LiveStaticFiles if enable_reload else StaticFiles
-    server = HTTPServer(address, handler)
-    server.working_dir = working_dir  # type: ignore
-    server.id = str(uuid4())  # type: ignore
-    return server
+class DevSever(HTTPServer):
+    def __init__(self, directory: str, *, host: str, port: int, enable_reload: bool):
+        self.working_dir = Path(directory).resolve()
+        check_directory(self.working_dir)
+        address = (host, port)
+        handler = LiveStaticFiles if enable_reload else StaticFiles
+        super(DevSever, self).__init__(address, handler)
+        if enable_reload:
+            _, self.id_path = mkstemp()  # type: ignore
 
 
 def check_directory(working_dir: Path):
@@ -114,7 +120,7 @@ const liveReload = function f() {
 
     function reloadOnChange(currentId) {
         stopped = false;
-        interval = setInterval(check, 500);
+        interval = setInterval(check, 1000);
 
         function check() {
             fetchId().then(newId => {
@@ -141,10 +147,30 @@ parser.add_argument('--host', type=str, default='0.0.0.0')
 parser.add_argument('--port', type=int, default=8080)
 parser.add_argument('--no-live-reload', action='store_true', default=False, help='disable live reloading')
 
+
+class ChangeId(FileSystemEventHandler):
+    def __init__(self, path: str):
+        super().__init__()
+        self.path = path
+        self.rewrite()
+
+    def on_any_event(self, event):
+        self.rewrite()
+
+    def rewrite(self):
+        with open(self.path, 'w') as f:
+            f.write(str(uuid4()))
+
+
 if __name__ == '__main__':
     args = parser.parse_args()
-    server = dev_server(args.directory,
-                        host=args.host,
-                        port=args.port,
-                        enable_reload=not args.no_live_reload)
+    enable_reload = not args.no_live_reload
+    server = DevSever(args.directory, host=args.host, port=args.port, enable_reload=enable_reload)
+
+    if enable_reload:
+        id_path = server.id_path  # type
+        observer = Observer()
+        observer.schedule(ChangeId(id_path), args.directory, recursive=True)
+        observer.start()
+
     server.serve_forever()

--- a/lightweight/site.py
+++ b/lightweight/site.py
@@ -62,7 +62,7 @@ class Site(ContentCollection):
         if self.out.exists():
             rmtree(self.out)
         self.out.mkdir(parents=True, exist_ok=True)
-        [content.render(self.path(p)) for p, content in self.content.items()]
+        [content.write(self.path(p)) for p, content in self.content.items()]
 
 
 def _file_or_dir(path: Path):

--- a/lightweight/site.py
+++ b/lightweight/site.py
@@ -13,13 +13,13 @@ from lightweight.path import SitePath
 
 
 class Site(ContentCollection):
-    content: Dict[Path, Content]
+    content: Dict[SitePath, Content]
 
     def __init__(self, *,
                  url: str,
                  out: Union[str, Path] = 'out',
                  title: Optional[str] = None):
-        super().__init__({})
+        super().__init__({}, self)
         url_parts = urlparse(url)
         assert url_parts.scheme, 'Missing scheme in Site URL.'
         self.title = title or url_parts.netloc
@@ -47,12 +47,12 @@ class Site(ContentCollection):
 
         pattern_or_path = arg  # type: Union[str, Path]
         if content is None:
-            contents = {path: _file_or_dir(path) for path in paths(pattern_or_path)}
+            contents = {self.path(path): file_or_dir(path) for path in paths(pattern_or_path)}
             if not len(contents):
                 raise FileNotFoundError()
             self.content.update(contents)
         else:
-            path = Path(pattern_or_path)
+            path = self.path(pattern_or_path)
             self.content[path] = content
 
     def path(self, p: Union[Path, str]) -> SitePath:
@@ -62,8 +62,8 @@ class Site(ContentCollection):
         if self.out.exists():
             rmtree(self.out)
         self.out.mkdir(parents=True, exist_ok=True)
-        [content.write(self.path(p)) for p, content in self.content.items()]
+        [content.write(p) for p, content in self.items()]
 
 
-def _file_or_dir(path: Path):
+def file_or_dir(path: Path):
     return FileCopy(path) if path.is_file() else DirectoryCopy(path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ pytest>=4.4.1
 pytest-cov>=2.6.1
 python-slugify>=3.0.3
 twine>=1.13.0
+watchdog>=0.9.0
 wheel>=0.33.6

--- a/tests/expected/feed/posts.atom.xml
+++ b/tests/expected/feed/posts.atom.xml
@@ -10,20 +10,6 @@
     <id>https://example.com/posts/post-1.html</id>
     <title>posts/post-1.html</title>
     <updated>2020-04-20T16:20:00-07:00</updated>
-    <content># This is a test
-One.
-
-## Second heading
-## Second heading part 2
-### Third heading
-#### 4th heading
-##### 5th heading
-###### 6th heading!
-
-## And Back
-
-
-</content>
     <link href="https://example.com/posts/post-1.html" rel="alternate"/>
     <published>2020-04-20T16:20:00-07:00</published>
   </entry>

--- a/tests/expected/feed/posts.rss.xml
+++ b/tests/expected/feed/posts.rss.xml
@@ -10,20 +10,6 @@
     <item>
       <title>posts/post-1.html</title>
       <link>https://example.com/posts/post-1.html</link>
-      <description># This is a test
-One.
-
-## Second heading
-## Second heading part 2
-### Third heading
-#### 4th heading
-##### 5th heading
-###### 6th heading!
-
-## And Back
-
-
-</description>
       <guid isPermaLink="false">https://example.com/posts/post-1.html</guid>
       <pubDate>Mon, 20 Apr 2020 16:20:00 -0700</pubDate>
     </item>

--- a/tests/expected/md/md-link.html
+++ b/tests/expected/md/md-link.html
@@ -1,0 +1,8 @@
+<html lang="en">
+<head><title>None</title></head>
+<body>
+<p><a href="https://example.com/plain">Link to another Markdown file</a></p>
+<p><a href="https://example.com/plain">Link to another Markdown file</a></p>
+
+</body>
+</html>

--- a/tests/resources/md/link.md
+++ b/tests/resources/md/link.md
@@ -1,0 +1,3 @@
+[Link to another Markdown file](resources/md/plain.md)
+
+[Link to another Markdown file](/resources/md/plain.md)

--- a/tests/test_include_feed.py
+++ b/tests/test_include_feed.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
-from lightweight import Site, feeds, markdown, template, paths
+from lightweight import Site, markdown, template, paths, atom, rss
 
 PDT = timezone(timedelta(hours=-7))
 apr_20 = datetime(2020, 4, 20, 16, 20, tzinfo=PDT)
@@ -17,8 +17,8 @@ def test_create_atom(tmp_path: Path):
     site.updated = apr_20
 
     [site.include(f'posts/{md.filename.stem}.html', md) for md in md_posts('resources/md/collection/*.md')]
-    posts = feeds(site['posts'])
-    site.include('posts.atom.xml', posts.atom)
+    posts = atom(site['posts'])
+    site.include('posts.atom.xml', posts)
 
     site.render()
 
@@ -33,8 +33,8 @@ def test_create_rss(tmp_path: Path):
     site.updated = apr_20
 
     [site.include(f'posts/{md.filename.stem}.html', md) for md in md_posts('resources/md/collection/*.md')]
-    posts = feeds(site['posts'])
-    site.include('posts.rss.xml', posts.rss)
+    posts = rss(site['posts'])
+    site.include('posts.rss.xml', posts)
 
     site.render()
 

--- a/tests/test_include_jinja.py
+++ b/tests/test_include_jinja.py
@@ -52,7 +52,7 @@ def test_render_jinja_file(tmp_path: Path):
 
 
 class NoopContent(Content):
-    def render(self, path: Path):
+    def write(self, path: Path):
         pass
 
 

--- a/tests/test_include_markdown.py
+++ b/tests/test_include_markdown.py
@@ -46,3 +46,20 @@ def test_render_file(tmp_path: Path):
     assert (test_out / out_location).exists()
     with open('expected/md/file.html') as expected:
         assert (test_out / out_location).read_text() == expected.read()
+
+
+def test_render_markdown_link(tmp_path: Path):
+    src_location = 'resources/md/link.md'
+    link_target_location = 'resources/md/plain.md'
+    out_location = 'md/file.html'
+
+    test_out = tmp_path / 'out'
+    site = Site(url='https://example.com', out=test_out)
+
+    site.include('plain.html', markdown(link_target_location, template('md/plain.html')))
+    site.include(out_location, markdown(src_location, template('md/plain.html')))
+    site.render()
+
+    assert (test_out / out_location).exists()
+    with open('expected/md/md-link.html') as expected:
+        assert (test_out / out_location).read_text() == expected.read()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,7 +4,7 @@ from http.server import HTTPServer
 
 import requests
 
-from lightweight.server import parser, dev_server, LIVE_RELOAD_JS
+from lightweight.server import parser, DevSever, LIVE_RELOAD_JS
 
 
 def test_args():
@@ -33,19 +33,19 @@ def background_server(server: HTTPServer):
 
 
 def test_serves_live_reload_js():
-    server = dev_server('site', host='0.0.0.0', port=8033, enable_reload=True)
+    server = DevSever('site', host='0.0.0.0', port=8033, enable_reload=True)
     with background_server(server):
         assert 'liveReload.start();' in requests.get('http://0.0.0.0:8033').text
         assert LIVE_RELOAD_JS in requests.get('http://0.0.0.0:8033').text
         assert LIVE_RELOAD_JS in requests.get('http://0.0.0.0:8033/index').text
         assert LIVE_RELOAD_JS in requests.get('http://0.0.0.0:8033/index.html').text
-        assert server.id == requests.get('http://0.0.0.0:8033/id').text
+        assert server.id_path
 
         assert 'A test file.' in requests.get('http://0.0.0.0:8033/file').text
 
 
 def test_serves_no_live_reload_js():
-    server = dev_server('site', host='0.0.0.0', port=8034, enable_reload=False)
+    server = DevSever('site', host='0.0.0.0', port=8034, enable_reload=False)
     with background_server(server):
         assert LIVE_RELOAD_JS not in requests.get('http://0.0.0.0:8034').text
         assert LIVE_RELOAD_JS not in requests.get('http://0.0.0.0:8034/index').text


### PR DESCRIPTION
Implement #11, finish #10.

Markdown can be linked to via direct references like `(ABC)[/posts/abc.md]` which will be resolved in accordance with site, e.g. `<a href="https://example.org/posts/abc">ABC</a>`.

Dev server has watchdog running looking for changes.