### PR TITLE
Lazy Jinja params

### DIFF
--- a/lightweight/__init__.py
+++ b/lightweight/__init__.py
@@ -4,4 +4,4 @@ from .files import paths, directory
 from .generation import GenPath, GenContext
 from .template import template, jinja_env
 
-__version__ = '1.0.0.dev33'
+__version__ = '1.0.0.dev34'

--- a/lightweight/__init__.py
+++ b/lightweight/__init__.py
@@ -1,5 +1,5 @@
 from .site import Site, Author
-from .content import Content, feeds, atom, rss, markdown, jinja, sass
+from .content import Content, feeds, atom, rss, markdown, jinja, from_ctx, sass
 from .files import paths, directory
 from .generation import GenPath, GenContext
 from .template import template, jinja_env

--- a/lightweight/content/__init__.py
+++ b/lightweight/content/__init__.py
@@ -1,5 +1,5 @@
 from .content import Content
 from .feeds import atom, rss
-from .jinja import jinja
+from .jinja import jinja, from_ctx
 from .markdown import markdown
 from .sass import sass

--- a/lightweight/content/jinja.py
+++ b/lightweight/content/jinja.py
@@ -15,12 +15,18 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class JinjaPage(Content):
+    """A file rendered from a Jinja Template."""
+
     template: Template
-    path: Path
+    source_path: Path
     params: Dict[str, Any]
 
     def write(self, path: GenPath, ctx: GenContext):
-        path.create(self.template.render(
+        path.create(self.render(ctx))
+
+    def render(self, ctx):
+        # TODO:mdrachuk:06.01.2020: warn if site, ctx, source are in params!
+        return self.template.render(
             site=ctx.site,
             ctx=ctx,
             source=self,
@@ -31,10 +37,11 @@ class JinjaPage(Content):
 def jinja(template_path: Union[str, Path], **params) -> JinjaPage:
     """Renders the page at path with provided parameters.
 
-    Templates are resolved from current directory (NOT `./templates/`)."""
+    Templates are resolved from the current directory (cwd).
+    """
     path = Path(template_path)
     return JinjaPage(
         template=template(path),
-        path=path,
+        source_path=path,
         params=params,
     )

--- a/tests/expected/jinja/lazy.html
+++ b/tests/expected/jinja/lazy.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Lazy</title>
+</head>
+<body>
+Hello there! lazy.html
+</body>
+</html>

--- a/tests/expected/md/lazy.html
+++ b/tests/expected/md/lazy.html
@@ -1,0 +1,16 @@
+<html lang="en">
+<head><title>This is a test</title></head>
+<body>
+<subtitle>Hello there! lazy.html</subtitle>
+<h1 id="this-is-a-test">This is a test</h1>
+<p>One.</p>
+<h2 id="second-heading">Second heading</h2>
+<h2 id="second-heading-part-2">Second heading part 2</h2>
+<h3 id="third-heading">Third heading</h3>
+<h4 id="4th-heading">4th heading</h4>
+<h5 id="5th-heading">5th heading</h5>
+<h6 id="6th-heading">6th heading!</h6>
+<h2 id="and-back">And Back</h2>
+
+</body>
+</html>

--- a/tests/resources/jinja/file.html
+++ b/tests/resources/jinja/file.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>{{ source.path.name }}</title>
+    <title>{{ content.source_path.name }}</title>
 </head>
 <body>
-filename: {{ source.path.name }}
-filename.name: {{ source.path.stem }}
-filename.extension: {{ source.path.suffix }}
+filename: {{ content.source_path.name }}
+filename.name: {{ content.source_path.stem }}
+filename.extension: {{ content.source_path.suffix }}
 
 </body>
 </html>

--- a/tests/resources/jinja/lazy.html
+++ b/tests/resources/jinja/lazy.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Lazy</title>
+</head>
+<body>
+{{ lazy }}
+</body>
+</html>

--- a/tests/templates/md/file.html
+++ b/tests/templates/md/file.html
@@ -1,9 +1,9 @@
 <html lang="en">
-<head><title>{{ source.path.name }}</title></head>
+<head><title>{{ content.source_path.name }}</title></head>
 <body>
-filename: {{ source.path.name }}
-filename.name: {{ source.path.stem }}
-filename.extension: {{ source.path.suffix }}
+filename: {{ content.source_path.name }}
+filename.name: {{ content.source_path.stem }}
+filename.extension: {{ content.source_path.suffix }}
 
 </body>
 </html>

--- a/tests/templates/md/lazy.html
+++ b/tests/templates/md/lazy.html
@@ -1,0 +1,7 @@
+<html lang="en">
+<head><title>{{ markdown.title }}</title></head>
+<body>
+<subtitle>{{ lazy }}</subtitle>
+{{ markdown.html }}
+</body>
+</html>

--- a/tests/test_include_feed.py
+++ b/tests/test_include_feed.py
@@ -20,7 +20,7 @@ def test_create_atom(tmp_path: Path):
     test_out = tmp_path / 'out'
     site = Site(url='https://example.com', title='Tests', description='Test site', updated=apr_20)
 
-    [site.include(f'posts/{md.path.stem}.html', md) for md in md_posts('resources/md/collection/*.md')]
+    [site.include(f'posts/{md.source_path.stem}.html', md) for md in md_posts('resources/md/collection/*.md')]
     site.include('posts.atom.xml', atom(site['posts']))
 
     site.generate(test_out)
@@ -34,7 +34,7 @@ def test_create_rss(tmp_path: Path):
     test_out = tmp_path / 'out'
     site = Site(url='https://example.com', title='Tests', description='Test site', updated=apr_20)
 
-    [site.include(f'posts/{md.path.stem}.html', md) for md in md_posts('resources/md/collection/*.md')]
+    [site.include(f'posts/{md.source_path.stem}.html', md) for md in md_posts('resources/md/collection/*.md')]
     site.include('posts.rss.xml', rss(site['posts']))
 
     site.generate(test_out)

--- a/tests/test_include_jinja.py
+++ b/tests/test_include_jinja.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from jinja2 import TemplateNotFound
 
-from lightweight import Site, jinja, Content, directory, GenContext, GenPath
+from lightweight import Site, jinja, Content, directory, GenContext, GenPath, from_ctx
 
 
 def test_render_jinja(tmp_path: Path):
@@ -70,3 +70,18 @@ def test_resolves_sub_site_template_by_cwd(tmp_path: Path):
 
     with open('expected/subsite/page.html') as expected:
         assert (tmp_path / 'subsite' / 'page.html').read_text() == expected.read()
+
+
+def test_lazy_params(tmp_path: Path):
+    src_location = 'resources/jinja/lazy.html'
+    out_location = 'lazy.html'
+
+    test_out = tmp_path / 'out'
+    site = Site(url='https://example.com')
+
+    site.include(out_location, jinja(src_location, lazy=from_ctx(lambda ctx: f'Hello there! {ctx.tasks[0].path}')))
+    site.generate(test_out)
+
+    assert (test_out / out_location).exists()
+    with open('expected/jinja/lazy.html') as expected:
+        assert (test_out / out_location).read_text() == expected.read()

--- a/tests/test_include_markdown.py
+++ b/tests/test_include_markdown.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from lightweight import Site, markdown, template, directory
+from lightweight import Site, markdown, template, directory, from_ctx
 
 
 def test_render_markdown(tmp_path: Path):
@@ -75,3 +75,19 @@ def test_resolves_sub_site_markdown_template_by_cwd(tmp_path: Path):
 
     with open('expected/subsite/markdown.html') as expected:
         assert (tmp_path / 'subsite' / 'markdown.html').read_text() == expected.read()
+
+
+def test_lazy_params(tmp_path: Path):
+    src_location = 'resources/md/collection/post-1.md'
+    out_location = 'lazy.html'
+
+    test_out = tmp_path / 'out'
+    site = Site(url='https://example.com')
+
+    site.include(out_location, markdown(src_location, template('templates/md/lazy.html'),
+                                        lazy=from_ctx(lambda ctx: f'Hello there! {ctx.tasks[0].path}')))
+    site.generate(test_out)
+
+    assert (test_out / out_location).exists()
+    with open('expected/md/lazy.html') as expected:
+        assert (test_out / out_location).read_text() == expected.read()


### PR DESCRIPTION
Some values are computed from GenContext. Doing this in templates is ugly. 

Thus, hereby `from_ctx(func)` is added allowing passing such properties as a `jinja(...)` or `markdown(...)` arguments.